### PR TITLE
Support rs/zerolog

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,29 @@
 
 A small collection of log adapters for [Watermill].
 
+The `LoggerAdapter` affords Watermill applications to bring their own loggers
+with their applications. This package provides lightly opinionated logger
+implementations that satisfy the `LoggerAdapter` interface so your logs are
+uniform across all components in your system.
+
+All implementations will follow these conventions:
+
+- logger structs are exported, named `Logger` and the underlying logger is
+  exported as `Logger.L`
+- new loggers use JSON formatting and use a constructor that matches
+  `func(output io.Writer, debug, trace bool) watermill.LoggerAdapter`
+- debug and trace are just boolean gates; they aren't separate loggers (unlike
+  `watermill.StdLoggerAdapter`)
+
 To Do
 
-- [ ] [go-kit/log]
-- [ ] [rs/zerolog]
+- [x] [go-kit/log]
+- [x] [rs/zerolog]
+- [ ] [sirupsen/logrus]
+- [ ] [uber-go/zap]
 
 [Watermill]: https://github.com/ThreeDotsLabs/watermill
 [go-kit/log]: https://github.com/go-kit/log
 [rs/zerolog]: https://github.com/rs/zerolog
+[sirupsen/logrus]: https://github.com/Sirupsen/logrus
+[uber-go/zap]: https://github.com/uber-go/zap

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,15 @@ go 1.18
 require (
 	github.com/ThreeDotsLabs/watermill v1.1.1
 	github.com/go-kit/log v0.2.1
+	github.com/rs/zerolog v1.27.0
 )
 
 require (
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/google/uuid v1.1.1 // indirect
 	github.com/lithammer/shortuuid/v3 v3.0.4 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
+	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
+github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -16,6 +17,7 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -32,6 +34,10 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/lithammer/shortuuid/v3 v3.0.4 h1:uj4xhotfY92Y1Oa6n6HUiFn87CdoEHYUlTy0+IgbLrs=
 github.com/lithammer/shortuuid/v3 v3.0.4/go.mod h1:RviRjexKqIzx/7r1peoAITm6m7gnif/h+0zmolKJjzw=
+github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
+github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
+github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
@@ -40,6 +46,7 @@ github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -49,6 +56,9 @@ github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
+github.com/rs/zerolog v1.27.0 h1:1T7qCieN22GVc8S4Q2yuexzBb1EqjbgjSH9RohbMjKs=
+github.com/rs/zerolog v1.27.0/go.mod h1:7frBqO0oezxmnO7GF86FY++uy8I0Tk/If5ni1G9Qc0U=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -61,6 +71,9 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 h1:foEbQz/B0Oz6YIqu/69kfXPYeFQAuuMYFkjaqXzl5Wo=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/kit/log.go
+++ b/kit/log.go
@@ -1,12 +1,14 @@
 package kit
 
 import (
+	"io"
+
 	"github.com/ThreeDotsLabs/watermill"
 	log "github.com/go-kit/log"
 )
 
-func New(l log.Logger, debug, trace bool) Logger {
-	return Logger{l, debug, trace}
+func New(output io.Writer, debug, trace bool) watermill.LoggerAdapter {
+	return Logger{log.NewJSONLogger(output), debug, trace}
 }
 
 type Logger struct {
@@ -21,14 +23,16 @@ func (l Logger) Log(keyvals ...interface{}) error {
 
 func (l Logger) Error(msg string, err error, fields watermill.LogFields) {
 	fields = lfs(fields)
-	fields["msg"] = msg
-	fields["err"] = err
+	fields["level"] = "error"
+	fields["message"] = msg
+	fields["error"] = err
 	l.Log(kvs(fields)...)
 }
 
 func (l Logger) Info(msg string, fields watermill.LogFields) {
 	fields = lfs(fields)
-	fields["msg"] = msg
+	fields["level"] = "info"
+	fields["message"] = msg
 	l.Log(kvs(fields)...)
 }
 
@@ -37,7 +41,8 @@ func (l Logger) Debug(msg string, fields watermill.LogFields) {
 		return
 	}
 	fields = lfs(fields)
-	fields["msg"] = msg
+	fields["level"] = "debug"
+	fields["message"] = msg
 	l.Log(kvs(fields)...)
 }
 
@@ -46,7 +51,8 @@ func (l Logger) Trace(msg string, fields watermill.LogFields) {
 		return
 	}
 	fields = lfs(fields)
-	fields["msg"] = msg
+	fields["level"] = "trace"
+	fields["message"] = msg
 	l.Log(kvs(fields)...)
 }
 

--- a/tests.go
+++ b/tests.go
@@ -1,0 +1,127 @@
+package waterlog
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/ThreeDotsLabs/watermill"
+)
+
+// AssertJSON asserts that two input strings are the same JSON value
+func AssertJSON(t *testing.T, act, exp string) {
+	var actjs, expjs map[string]interface{}
+	if act == exp {
+		return
+	}
+	if err := json.Unmarshal([]byte(act), &actjs); err != nil {
+		t.Fatalf("unexpected err: %s; act=%q exp=%q", err, act, exp)
+	}
+	if err := json.Unmarshal([]byte(exp), &expjs); err != nil {
+		t.Fatalf("unexpected err: %s; act=%q exp=%q", err, act, exp)
+	}
+	if !reflect.DeepEqual(expjs, actjs) {
+		t.Fatalf("expected %s but got %s", exp, act)
+	}
+}
+
+func TestLogger(t *testing.T, newLogger NewFunc) {
+	tests := map[string]func(b *bytes.Buffer, l watermill.LoggerAdapter) func(t *testing.T){
+		"TestError":       TestError,
+		"TestErrorFields": TestErrorFields,
+		"TestInfo":        TestInfo,
+		"TestInfoFields":  TestInfoFields,
+		"TestDebug":       TestDebug,
+		"TestDebugFields": TestDebugFields,
+		"TestTrace":       TestTrace,
+		"TestTraceFields": TestTraceFields,
+		"TestWith":        TestWith,
+	}
+	for name, test := range tests {
+		output := &bytes.Buffer{}
+		debug := name == "TestDebug" || name == "TestDebugFields"
+		trace := name == "TestTrace" || name == "TestTraceFields"
+		logger := newLogger(output, debug, trace)
+		t.Run(name, test(output, logger))
+	}
+}
+
+func TestError(b *bytes.Buffer, l watermill.LoggerAdapter) func(t *testing.T) {
+	return func(t *testing.T) {
+		l.Error("message", errors.New("error"), nil)
+		AssertJSON(t, b.String(), `{"error":"error","message":"message","level":"error"}`)
+	}
+}
+
+func TestErrorFields(b *bytes.Buffer, l watermill.LoggerAdapter) func(t *testing.T) {
+	return func(t *testing.T) {
+		l.Error("message", errors.New("error"), watermill.LogFields{"foo": "bar"})
+		AssertJSON(t, b.String(), `{"error":"error","message":"message","level":"error","foo":"bar"}`)
+	}
+}
+
+func TestInfo(b *bytes.Buffer, l watermill.LoggerAdapter) func(t *testing.T) {
+	return func(t *testing.T) {
+		l.Info("message", nil)
+		AssertJSON(t, b.String(), `{"message":"message","level":"info"}`)
+	}
+}
+
+func TestInfoFields(b *bytes.Buffer, l watermill.LoggerAdapter) func(t *testing.T) {
+	return func(t *testing.T) {
+		l.Info("message", watermill.LogFields{"foo": "bar"})
+		AssertJSON(t, b.String(), `{"message":"message","level":"info","foo":"bar"}`)
+	}
+}
+
+func TestDebug(b *bytes.Buffer, l watermill.LoggerAdapter) func(t *testing.T) {
+	return func(t *testing.T) {
+		l.Debug("message", nil)
+		AssertJSON(t, b.String(), `{"message":"message","level":"debug"}`)
+	}
+}
+
+func TestDebugDisabled(b *bytes.Buffer, l watermill.LoggerAdapter) func(t *testing.T) {
+	return func(t *testing.T) {
+		l.Debug("message", nil)
+		AssertJSON(t, b.String(), "")
+	}
+}
+
+func TestDebugFields(b *bytes.Buffer, l watermill.LoggerAdapter) func(t *testing.T) {
+	return func(t *testing.T) {
+		l.Debug("message", watermill.LogFields{"foo": "bar"})
+		AssertJSON(t, b.String(), `{"message":"message","level":"debug","foo":"bar"}`)
+	}
+}
+
+func TestTrace(b *bytes.Buffer, l watermill.LoggerAdapter) func(t *testing.T) {
+	return func(t *testing.T) {
+		l.Trace("message", nil)
+		AssertJSON(t, b.String(), `{"message":"message","level":"trace"}`)
+	}
+}
+
+func TestTraceDisabled(b *bytes.Buffer, l watermill.LoggerAdapter) func(t *testing.T) {
+	return func(t *testing.T) {
+		l.Trace("message", nil)
+		AssertJSON(t, b.String(), "")
+	}
+}
+
+func TestTraceFields(b *bytes.Buffer, l watermill.LoggerAdapter) func(t *testing.T) {
+	return func(t *testing.T) {
+		l.Trace("message", watermill.LogFields{"foo": "bar"})
+		AssertJSON(t, b.String(), `{"message":"message","level":"trace","foo":"bar"}`)
+	}
+}
+
+func TestWith(b *bytes.Buffer, l watermill.LoggerAdapter) func(t *testing.T) {
+	return func(t *testing.T) {
+		w := l.With(watermill.LogFields{"foo": "bar", "baz": "bif"})
+		w.Info("message", nil)
+		AssertJSON(t, b.String(), `{"message":"message","level":"info","foo":"bar","baz":"bif"}`)
+	}
+}

--- a/waterlog.go
+++ b/waterlog.go
@@ -1,0 +1,10 @@
+package waterlog
+
+import (
+	"io"
+
+	"github.com/ThreeDotsLabs/watermill"
+)
+
+// NewFunc matches constructors for every logger implementation
+type NewFunc func(output io.Writer, debug, trace bool) watermill.LoggerAdapter

--- a/zero/log.go
+++ b/zero/log.go
@@ -1,0 +1,60 @@
+package zero
+
+import (
+	"io"
+
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/rs/zerolog"
+)
+
+func New(output io.Writer, debug, trace bool) watermill.LoggerAdapter {
+	return Logger{zerolog.New(output), debug, trace}
+}
+
+type Logger struct {
+	L     zerolog.Logger
+	debug bool
+	trace bool
+}
+
+func (l Logger) Error(msg string, err error, fields watermill.LogFields) {
+	ev := l.L.Error().Err(err)
+	for k, v := range fields {
+		ev = ev.Interface(k, v)
+	}
+	ev.Msg(msg)
+}
+func (l Logger) Info(msg string, fields watermill.LogFields) {
+	ev := l.L.Info()
+	for k, v := range fields {
+		ev = ev.Interface(k, v)
+	}
+	ev.Msg(msg)
+}
+func (l Logger) Debug(msg string, fields watermill.LogFields) {
+	if !l.debug {
+		return
+	}
+	ev := l.L.Debug()
+	for k, v := range fields {
+		ev = ev.Interface(k, v)
+	}
+	ev.Msg(msg)
+}
+func (l Logger) Trace(msg string, fields watermill.LogFields) {
+	if !l.trace {
+		return
+	}
+	ev := l.L.Trace()
+	for k, v := range fields {
+		ev = ev.Interface(k, v)
+	}
+	ev.Msg(msg)
+}
+func (l Logger) With(fields watermill.LogFields) watermill.LoggerAdapter {
+	ctx := l.L.With()
+	for k, v := range fields {
+		ctx = ctx.Interface(k, v)
+	}
+	return &Logger{ctx.Logger(), l.debug, l.trace}
+}

--- a/zero/log_test.go
+++ b/zero/log_test.go
@@ -1,4 +1,4 @@
-package kit
+package zero
 
 import (
 	"testing"


### PR DESCRIPTION
Adds support for rs/zerolog

Additionally:

- defines a `waterlog.NewFunc` which all implementations will conform to
- creates a suite of tests to test all loggers uniformly