### PR TITLE
Support sirupsen/logrus

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To Do
 
 - [x] [go-kit/log]
 - [x] [rs/zerolog]
-- [ ] [sirupsen/logrus]
+- [x] [sirupsen/logrus]
 - [ ] [uber-go/zap]
 
 [Watermill]: https://github.com/ThreeDotsLabs/watermill

--- a/go.mod
+++ b/go.mod
@@ -6,14 +6,17 @@ require (
 	github.com/ThreeDotsLabs/watermill v1.1.1
 	github.com/go-kit/log v0.2.1
 	github.com/rs/zerolog v1.27.0
+	github.com/sirupsen/logrus v1.2.0
 )
 
 require (
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/google/uuid v1.1.1 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
 	github.com/lithammer/shortuuid/v3 v3.0.4 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
+	golang.org/x/crypto v0.0.0-20180904163835-0709b304e793 // indirect
 	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,7 @@ github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/lithammer/shortuuid/v3 v3.0.4 h1:uj4xhotfY92Y1Oa6n6HUiFn87CdoEHYUlTy0+IgbLrs=
@@ -59,12 +60,14 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.27.0 h1:1T7qCieN22GVc8S4Q2yuexzBb1EqjbgjSH9RohbMjKs=
 github.com/rs/zerolog v1.27.0/go.mod h1:7frBqO0oezxmnO7GF86FY++uy8I0Tk/If5ni1G9Qc0U=
+github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/crypto v0.0.0-20180904163835-0709b304e793 h1:u+LnwYTOOW7Ukr/fppxEb1Nwz0AtPflrblfvUudpo+I=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/logrus/log.go
+++ b/logrus/log.go
@@ -1,0 +1,72 @@
+package logrus
+
+import (
+	"io"
+
+	"git.sr.ht/~mgirouard/waterlog"
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/sirupsen/logrus"
+)
+
+func New(output io.Writer, debug, trace bool) watermill.LoggerAdapter {
+	fmt := &logrus.JSONFormatter{
+		DisableTimestamp: true,
+		FieldMap: logrus.FieldMap{
+			logrus.FieldKeyMsg: "message",
+		},
+	}
+	return Logger{
+		L: &logrus.Logger{
+			Out:       output,
+			Formatter: fmt,
+			Hooks:     make(logrus.LevelHooks),
+			Level:     logrus.TraceLevel,
+		},
+		Opts: waterlog.Opts{debug, trace},
+	}
+}
+
+type Logger struct {
+	L      *logrus.Logger
+	fields logrus.Fields
+	waterlog.Opts
+}
+
+func (l Logger) Error(msg string, err error, fields watermill.LogFields) {
+	l.L.
+		WithFields(l.fields).
+		WithFields(logrus.Fields(fields)).
+		WithField("error", err).
+		Error(msg)
+}
+func (l Logger) Info(msg string, fields watermill.LogFields) {
+	l.L.
+		WithFields(l.fields).
+		WithFields(logrus.Fields(fields)).
+		Info(msg)
+}
+func (l Logger) Debug(msg string, fields watermill.LogFields) {
+	if !l.Opts.Debug {
+		return
+	}
+	l.L.
+		WithFields(l.fields).
+		WithFields(logrus.Fields(fields)).
+		Debug(msg)
+}
+func (l Logger) Trace(msg string, fields watermill.LogFields) {
+	if !l.Opts.Trace {
+		return
+	}
+	l.L.
+		WithFields(l.fields).
+		WithFields(logrus.Fields(fields)).
+		Trace(msg)
+}
+func (l Logger) With(fields watermill.LogFields) watermill.LoggerAdapter {
+	return &Logger{
+		L:      l.L,
+		fields: logrus.Fields(fields),
+		Opts:   l.Opts,
+	}
+}

--- a/logrus/log_test.go
+++ b/logrus/log_test.go
@@ -1,4 +1,4 @@
-package zero
+package logrus
 
 import (
 	"testing"
@@ -6,6 +6,6 @@ import (
 	"git.sr.ht/~mgirouard/waterlog"
 )
 
-func TestZero(t *testing.T) {
+func TestLogrus(t *testing.T) {
 	waterlog.TestLogger(t, New)
 }

--- a/waterlog.go
+++ b/waterlog.go
@@ -8,3 +8,9 @@ import (
 
 // NewFunc matches constructors for every logger implementation
 type NewFunc func(output io.Writer, debug, trace bool) watermill.LoggerAdapter
+
+// Opts controls global features across all loggers
+type Opts struct {
+	Debug bool
+	Trace bool
+}

--- a/zero/log.go
+++ b/zero/log.go
@@ -3,18 +3,21 @@ package zero
 import (
 	"io"
 
+	"git.sr.ht/~mgirouard/waterlog"
 	"github.com/ThreeDotsLabs/watermill"
 	"github.com/rs/zerolog"
 )
 
 func New(output io.Writer, debug, trace bool) watermill.LoggerAdapter {
-	return Logger{zerolog.New(output), debug, trace}
+	return Logger{
+		L:    zerolog.New(output),
+		Opts: waterlog.Opts{debug, trace},
+	}
 }
 
 type Logger struct {
-	L     zerolog.Logger
-	debug bool
-	trace bool
+	L zerolog.Logger
+	waterlog.Opts
 }
 
 func (l Logger) Error(msg string, err error, fields watermill.LogFields) {
@@ -32,7 +35,7 @@ func (l Logger) Info(msg string, fields watermill.LogFields) {
 	ev.Msg(msg)
 }
 func (l Logger) Debug(msg string, fields watermill.LogFields) {
-	if !l.debug {
+	if !l.Opts.Debug {
 		return
 	}
 	ev := l.L.Debug()
@@ -42,7 +45,7 @@ func (l Logger) Debug(msg string, fields watermill.LogFields) {
 	ev.Msg(msg)
 }
 func (l Logger) Trace(msg string, fields watermill.LogFields) {
-	if !l.trace {
+	if !l.Opts.Trace {
 		return
 	}
 	ev := l.L.Trace()
@@ -56,5 +59,8 @@ func (l Logger) With(fields watermill.LogFields) watermill.LoggerAdapter {
 	for k, v := range fields {
 		ctx = ctx.Interface(k, v)
 	}
-	return &Logger{ctx.Logger(), l.debug, l.trace}
+	return &Logger{
+		L:    ctx.Logger(),
+		Opts: l.Opts,
+	}
 }


### PR DESCRIPTION
Adds support for sirupsen/logrs

Additionally:

- make options a little easier to deal with by embedding a `waterlog.Opts`
  field in each logger